### PR TITLE
add support for firefox and older versions of chrome

### DIFF
--- a/node.js
+++ b/node.js
@@ -7,6 +7,8 @@ function renderNode (node) {
     class: 'body',
     x: 0,
     y: 0,
+    rx: '8px',
+    ry: '8px',
     width: 100,
     height: 100
   })
@@ -15,6 +17,7 @@ function renderNode (node) {
     return h('circle', {
       class: 'port input',
       id: node.id + '-inport-' + name,
+      r: 5,
       cx: 0,
       cy: (i + 1) * 100 / (node.inports.length + 1)
     })
@@ -24,13 +27,19 @@ function renderNode (node) {
     return h('circle', {
       class: 'port output',
       id: node.id + '-outport-' + name,
+      r: 5,
       cx: 100,
       cy: (i + 1) * 100 / (node.outports.length + 1)
     })
   }))
 
   var closeButton = h('rect', {
-    class: 'close'
+    class: 'close',
+    x: 5,
+    y: 5,
+    width: '10px',
+    height: '10px',
+    rx: 2
   })
   var text = h('text', {x: 50, y: 50}, node.label || node.id)
   var domNode = h('g', {

--- a/style.css
+++ b/style.css
@@ -9,8 +9,6 @@ svg .node {
   cursor: -webkit-grab;
 }
 svg .node .body {
-  rx: 8px;
-  ry: 8px;
   stroke: black;
   stroke-width: 3px;
 }
@@ -26,7 +24,6 @@ svg .node text {
 }
 svg .port {
   cursor: pointer;
-  r: 5;
   stroke: black;
   stroke-width: 3px;
 }
@@ -58,11 +55,6 @@ svg .edgeactive {
 
 svg .node .close {
   fill:  #FF5E56;
-  x: 5;
-  y: 5;
-  width: 10px;
-  height: 10px;
-  rx: 2;
   cursor: not-allowed;
   transition: height 0.2s, width 0.2s, x 0.2s, y 0.2s;
 }


### PR DESCRIPTION
Firefox and older versions of chrome(I noticed on my weird compiled version of chromium) do not support certain svg attributes(`specific attributes`) to be defined in css. This pr adds minimal support to make flowgraph-editor usable in firefox. The hover effects still do not work in firefox, but they really aren't necessary for basic usage.
